### PR TITLE
✨ TJ-7 페이지네이션 구현

### DIFF
--- a/components/Pagination/components/ArrowButton.tsx
+++ b/components/Pagination/components/ArrowButton.tsx
@@ -1,0 +1,32 @@
+import styled from "@emotion/styled";
+import Image from "next/image";
+
+type ArrowButtonProps = {
+  type: "prev" | "next";
+  onClick: () => void;
+  isDisabled: boolean;
+};
+
+export default function ArrowButton({
+  type,
+  onClick,
+  isDisabled,
+}: ArrowButtonProps) {
+  return (
+    <NextButton disabled={isDisabled} onClick={onClick}>
+      <Image
+        src={
+          type === "next" ? "/images/arrow-right.svg" : "/images/arrow-left.svg"
+        }
+        alt="화살표 버튼"
+        width={20}
+        height={20}
+      />
+    </NextButton>
+  );
+}
+
+const NextButton = styled.button<{ disabled: boolean }>`
+  cursor: ${({ disabled }) => (disabled ? "default" : "pointer")};
+  height: 24px;
+`;

--- a/components/Pagination/components/PageButton.tsx
+++ b/components/Pagination/components/PageButton.tsx
@@ -1,0 +1,58 @@
+import { body2Regular } from "@/styles/fontsStyle";
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+
+type PageIndexProps = {
+  pageIndex: number;
+  onClick: (page: number) => void;
+  page: number;
+};
+
+export default function PageButton({
+  pageIndex,
+  onClick,
+  page,
+}: PageIndexProps) {
+  const isNow = page === pageIndex;
+
+  const handleClick = () => {
+    onClick(pageIndex);
+  };
+
+  return (
+    <StyledButton isnow={isNow} disabled={isNow} onClick={handleClick}>
+      {pageIndex}
+    </StyledButton>
+  );
+}
+
+const StyledButton = styled.button<{ isnow: boolean }>`
+  cursor: ${({ disabled }) => (disabled ? "default" : "pointer")};
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+  padding: 12px;
+  ${body2Regular}
+
+  ${({ isnow }) =>
+    isnow
+      ? css`
+          background: var(--The-julge-purple-30);
+          color: var(----The-julge-white, #fff);
+        `
+      : css`
+          background: var(--The-julge-white);
+          color: var(----The-julge-black);
+        `}
+
+  &:hover {
+    ${({ isnow }) =>
+      isnow ||
+      css`
+        background: var(--The-julge-purple-10);
+      `}
+  }
+`;

--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -1,4 +1,5 @@
 import { getCurrentPageArray } from "@/lib/utils/getPaginationArray";
+import { useRouter } from "next/router";
 import styled from "@emotion/styled";
 import ArrowButton from "./components/ArrowButton";
 import PageButton from "./components/PageButton";
@@ -6,32 +7,29 @@ import PageButton from "./components/PageButton";
 type PaginationProps = {
   count: number;
   limit: number;
-  currentPage: number;
-  setPage: (page: number) => void;
 };
 
-export default function Pagination({
-  count,
-  limit,
-  currentPage,
-  setPage,
-}: PaginationProps) {
+export default function Pagination({ count, limit }: PaginationProps) {
+  const router = useRouter();
+  const { page } = router.query;
+
+  const currentPage = Number(page) >= 1 ? Number(page) : 1;
   const { currentPageArray, hasPrev, hasNext } = getCurrentPageArray(
     currentPage,
     count,
     limit,
   );
 
-  const handlePageClick = (pageIndex: number) => {
-    setPage(pageIndex);
+  const handlePageClick = (page: number) => {
+    router.push(`/test?page=${page}`);
   };
 
   const handlePrevClick = () => {
-    setPage(currentPage - 1);
+    router.push(`/test?page=${currentPage - 1}`);
   };
 
   const handleNextClick = () => {
-    setPage(currentPage + 1);
+    router.push(`/test?page=${currentPage - 1}`);
   };
 
   return (

--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -29,7 +29,7 @@ export default function Pagination({ count, limit }: PaginationProps) {
   };
 
   const handleNextClick = () => {
-    router.push(`/test?page=${currentPage - 1}`);
+    router.push(`/test?page=${currentPage + 1}`);
   };
 
   return (

--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -7,11 +7,13 @@ import PageButton from "./components/PageButton";
 type PaginationProps = {
   count: number;
   limit: number;
+  setPage?: () => void;
 };
 
-export default function Pagination({ count, limit }: PaginationProps) {
+export default function Pagination({ count, limit, setPage }: PaginationProps) {
   const router = useRouter();
   const { page } = router.query;
+  const basePath = router.pathname;
 
   const currentPage = Number(page) >= 1 ? Number(page) : 1;
   const { currentPageArray, hasPrev, hasNext } = getCurrentPageArray(
@@ -21,15 +23,15 @@ export default function Pagination({ count, limit }: PaginationProps) {
   );
 
   const handlePageClick = (page: number) => {
-    router.push(`/test?page=${page}`);
+    router.push(`${basePath}?page=${page}`);
   };
 
   const handlePrevClick = () => {
-    router.push(`/test?page=${currentPage - 1}`);
+    handlePageClick(currentPage - 1);
   };
 
   const handleNextClick = () => {
-    router.push(`/test?page=${currentPage + 1}`);
+    handlePageClick(currentPage + 1);
   };
 
   return (
@@ -46,7 +48,7 @@ export default function Pagination({ count, limit }: PaginationProps) {
               key={idx}
               pageIndex={idx}
               page={currentPage}
-              onClick={handlePageClick}
+              onClick={setPage || handlePageClick}
             />
           ))}
       </PageButtonContainer>

--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -4,18 +4,18 @@ import ArrowButton from "./components/ArrowButton";
 import PageButton from "./components/PageButton";
 
 type PaginationProps = {
-  data: any;
+  count: number;
+  limit: number;
   currentPage: number;
   setPage: (page: number) => void;
 };
 
 export default function Pagination({
-  data,
+  count,
+  limit,
   currentPage,
   setPage,
 }: PaginationProps) {
-  console.log(currentPage);
-  const { count, limit } = data;
   const { currentPageArray, hasPrev, hasNext } = getCurrentPageArray(
     currentPage,
     count,

--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -1,0 +1,74 @@
+import { getCurrentPageArray } from "@/lib/utils/getPaginationArray";
+import styled from "@emotion/styled";
+import ArrowButton from "./components/ArrowButton";
+import PageButton from "./components/PageButton";
+
+type PaginationProps = {
+  data: any;
+  currentPage: number;
+  setPage: (page: number) => void;
+};
+
+export default function Pagination({
+  data,
+  currentPage,
+  setPage,
+}: PaginationProps) {
+  console.log(currentPage);
+  const { count, limit } = data;
+  const { currentPageArray, hasPrev, hasNext } = getCurrentPageArray(
+    currentPage,
+    count,
+    limit,
+  );
+
+  const handlePageClick = (pageIndex: number) => {
+    setPage(pageIndex);
+  };
+
+  const handlePrevClick = () => {
+    setPage(currentPage - 1);
+  };
+
+  const handleNextClick = () => {
+    setPage(currentPage + 1);
+  };
+
+  return (
+    <Wrapper>
+      <ArrowButton
+        type="prev"
+        onClick={handlePrevClick}
+        isDisabled={!hasPrev}
+      />
+      <PageButtonContainer>
+        {typeof currentPageArray &&
+          currentPageArray.map((idx: any) => (
+            <PageButton
+              key={idx}
+              pageIndex={idx}
+              page={currentPage}
+              onClick={handlePageClick}
+            />
+          ))}
+      </PageButtonContainer>
+      <ArrowButton
+        type="next"
+        onClick={handleNextClick}
+        isDisabled={!hasNext}
+      />
+    </Wrapper>
+  );
+}
+
+const PageButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 2px;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 20px;
+`;

--- a/lib/utils/getPaginationArray.ts
+++ b/lib/utils/getPaginationArray.ts
@@ -1,0 +1,60 @@
+const PAGE_ARRAY_LIMIT = 5;
+
+type PaginationUtilProps = {
+  currentPageArray: number[] | [];
+  hasPrev: boolean;
+  hasNext: boolean;
+};
+
+export function getCurrentPageArray(
+  currentPage: number,
+  count: number,
+  limit: number,
+): PaginationUtilProps {
+  currentPage = currentPage >= 1 ? currentPage : 1;
+  const totalPage = calculateTotalPage(count, limit);
+  const startIndex = getStratIndex(currentPage);
+  const currentPageArray = getCurrentPageArrayLength(
+    startIndex,
+    currentPage,
+    totalPage,
+  );
+  const hasPrev = currentPage > 1;
+  const hasNext = currentPage < totalPage;
+  console.log(hasPrev, hasNext);
+
+  return { currentPageArray, hasPrev, hasNext };
+}
+
+function calculateTotalPage(count: number, limit: number) {
+  return Math.ceil(count / limit);
+}
+
+function getStratIndex(currentPage: number) {
+  currentPage = currentPage >= 1 ? currentPage : 1;
+  return (
+    Math.floor((currentPage - 1) / PAGE_ARRAY_LIMIT) * PAGE_ARRAY_LIMIT + 1
+  );
+}
+
+function getCurrentPageArrayLength(
+  startIndex: number,
+  currentPage: number,
+  totalPage: number,
+) {
+  // 잘못된 페이지 값 입력
+  if (currentPage > totalPage) {
+    return [];
+  }
+
+  // 페이지네이션 limit 만큼 출력하는 경우 - 페이지네이션 limit 보다 총 페이지 수가 더 많을 때
+  if (startIndex + PAGE_ARRAY_LIMIT - 1 <= totalPage) {
+    const arr = new Array(PAGE_ARRAY_LIMIT).fill(0);
+    return arr.map((x, i) => i + startIndex);
+  } else {
+    // 페이지네이션 limit 보다 적게 출력하는 경우
+    const length = totalPage - startIndex + 1;
+    const arr = new Array(length).fill(0);
+    return arr.map((x, i) => i + startIndex);
+  }
+}

--- a/lib/utils/getPaginationArray.ts
+++ b/lib/utils/getPaginationArray.ts
@@ -21,7 +21,6 @@ export function getCurrentPageArray(
   );
   const hasPrev = currentPage > 1;
   const hasNext = currentPage < totalPage;
-  console.log(hasPrev, hasNext);
 
   return { currentPageArray, hasPrev, hasNext };
 }

--- a/lib/utils/getPaginationArray.ts
+++ b/lib/utils/getPaginationArray.ts
@@ -1,4 +1,4 @@
-const PAGE_ARRAY_LIMIT = 5;
+const PAGE_ARRAY_LIMIT = 7;
 
 type PaginationUtilProps = {
   currentPageArray: number[] | [];
@@ -11,7 +11,6 @@ export function getCurrentPageArray(
   count: number,
   limit: number,
 ): PaginationUtilProps {
-  currentPage = currentPage >= 1 ? currentPage : 1;
   const totalPage = calculateTotalPage(count, limit);
   const startIndex = getStratIndex(currentPage);
   const currentPageArray = getCurrentPageArrayLength(


### PR DESCRIPTION
## 주요 변경 사항
- 페이지네이션 구현

## 관련 이슈
![2024-03-17 04;32;48](https://github.com/the-julge/the-julge/assets/119824778/4f276e6d-0b12-450d-9a06-a7c3c7ef254b)
- useRouter를 이용해서 페이지네이션 합니다.
- url 쿼리스트링으로 페이지 이동을 해주셔야 합니다.
- API 요청에서 받는 count과 limit 값만 넣으면 나머지는 내부에서 처리합니다.
- 페이지 버튼 누르면 현재 basePath 기준으로 basePath?page={page} 로 이동합니다.
- 페이지네이션 버튼의 최대 값은 시안대로 7로 했습니다.
- 화살표 색깔 바꾸는법을 모르겠어서 일단 냅뒀어요.
- setPage는 optional 하게 받을 수 있게 해서 setPage를 프롭으로 안주면 기본 동작을 합니다.
- 만약 다른 쿼리스트링을 쓰는 페이지에서 사용한다면 부모 컴포넌트에서 setPage로 
basePath?keyword={keyword}&page={page} 이런 식으로 이동 시키도록 써주시면 될것 같습니다.

## 관련 스크린샷
![ezgif-3-eb23ad9c7f](https://github.com/the-julge/the-julge/assets/119824778/a55aad88-6a5f-45d0-adae-f383bcb12dd5)

## 테스트 계획 또는 완료 사항
- 화살표 색 바꾸는 방법 깨달으면 바꿀 예정

## 리뷰어에게
- 변경해야할 부분이 있으면 말씀해주시면 반영하겠습니다.
- 쓰기 불편한 부분이 있으면 말씀해주세요.
