### PR TITLE
✨ TJ-62 쿠키에 토큰 및 유저 정보 담기

### DIFF
--- a/pages/signin/components/SigninForm/index.tsx
+++ b/pages/signin/components/SigninForm/index.tsx
@@ -28,7 +28,7 @@ export default function SigninForm() {
 
   const { email: emailError, password: passwordError } = errors;
 
-  const onSubmit = async (formData: any) => {
+  const onSubmit = async (formData: SigninFormData) => {
     const isValid = validateSigninData(formData);
     if (!isValid) {
       alert(WRONG_INFORMATION);

--- a/pages/signin/components/SigninForm/index.tsx
+++ b/pages/signin/components/SigninForm/index.tsx
@@ -11,6 +11,7 @@ import Button from "@/components/Button/Button";
 import styled from "@emotion/styled";
 import Input from "@/components/Input";
 import axios from "axios";
+import fetchData from "@/lib/apis/fetchData";
 
 const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
 const passwordRegex = /^.{8,}$/;
@@ -36,8 +37,13 @@ export default function SigninForm() {
 
     try {
       const { data } = await axios.post(`${BASE_URL}/token`, formData);
-      const { token } = data.item;
+      const { token, user } = data.item;
+      const { id, type } = user.item;
+
       document.cookie = `Authorization=Bearer ${token}; path=/`;
+      document.cookie = `Id=${id}; path=/`;
+      document.cookie = `UserType=${type}; path=/`;
+
       router.push("/");
     } catch (error) {
       if (axios.isAxiosError(error) && error.response) {

--- a/pages/signin/components/SigninForm/index.tsx
+++ b/pages/signin/components/SigninForm/index.tsx
@@ -15,7 +15,7 @@ import axios from "axios";
 const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
 const passwordRegex = /^.{8,}$/;
 
-const BASE_URL = "https://bootcamp-api.codeit.kr/api/3-3/the-julge";
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 export default function SigninForm() {
   const {
@@ -27,7 +27,7 @@ export default function SigninForm() {
 
   const { email: emailError, password: passwordError } = errors;
 
-  const onSubmit = async (formData: SigninFormData) => {
+  const onSubmit = async (formData: any) => {
     const isValid = validateSigninData(formData);
     if (!isValid) {
       alert(WRONG_INFORMATION);
@@ -37,7 +37,7 @@ export default function SigninForm() {
     try {
       const { data } = await axios.post(`${BASE_URL}/token`, formData);
       const { token } = data.item;
-      localStorage.setItem("accessToken", token);
+      document.cookie = `Authorization=Bearer ${token}; path=/`;
       router.push("/");
     } catch (error) {
       if (axios.isAxiosError(error) && error.response) {


### PR DESCRIPTION
## 주요 변경 사항
- 토큰, 유저 id, 유저 타입도 쿠키에 넣어서 매 요청마다 이용할 수 있습니다.
- 기존에 로컬스토리지에 토큰 저장하는 기능은 지웠습니다.

## 쿠키 사용법
### 엔드포인트를 Next.js의 api로 설정
![image](https://github.com/the-julge/the-julge/assets/119824778/c13665d7-e9c4-419e-acc9-c1b6b7861e3f)
![image](https://github.com/the-julge/the-julge/assets/119824778/14ff32fb-77d8-483c-bc67-1c2fb9abf73b)
pages 하위에 api 폴더에 path에 해당하는 이름의 파일을 만듭니다.
저희 next.config 설정해둬서 page.ts로 지어주셔야 정상 동작합니다.
### Next.js의 api 기능 사용
![image](https://github.com/the-julge/the-julge/assets/119824778/88cb800d-7f53-4d3f-8d36-0d6bb9f5175c)
위 예시는 예외처리 안해둔거라 다른 미들웨어 역할을 하는 라이브러리를 쓰는게 더 편할수도 있습니다.
패키지 추가하는기보단 일단 Next.js에서 제공하는 기본 기능 썼어요.

## 테스트 계획 또는 완료 사항
- 모든 페이지에서 토큰, 유저 id, 유저 타입 사용 가능
- 쿠키 관련 설정이라 로컬에서는 잘 되는데 배포됐을 때 CORS 문제가 생길 수도 있을것 같습니다.
- 문제 생기면 그때 수정해볼게요.

## 리뷰어에게
- 성경님 말씀대로 상태 관리 라이브러리는 다른 탭이랑 상태를 공유하지 않아서 쿠키에 저장했습니다.
- 변경해야할 부분이 있으면 말씀해주시면 반영하겠습니다.
- 쓰기 불편한 부분이 있으면 말씀해주세요.
