### PR TITLE
✨ TJ-71  권한별 추천 공고 DATA 변경

### DIFF
--- a/hooks/useUserQuery.ts
+++ b/hooks/useUserQuery.ts
@@ -18,12 +18,12 @@ interface GetNoticesProp {
 }
 
 export const useUserData = (userId: string) => {
-  return useQuery("user", () => fetchUser(userId));
+  return useQuery("user", () => fetchUser(userId), { enabled: !!userId });
 };
 
 export const useNoticesData = (address: string) => {
   return useQuery(["notices", address], () => fetchNotices(address), {
-    enabled: !!address, // address가 truthy 값일 때만 쿼리 실행
+    enabled: !!address,
     onSuccess: (data) => {
       if (data?.items?.length === 0) {
         fetchAllNotices();

--- a/pages/search/components/RecommendNotice/constants/constants.ts
+++ b/pages/search/components/RecommendNotice/constants/constants.ts
@@ -1,0 +1,1 @@
+export const BASE_ADDRESS = "서울시 종로구";

--- a/pages/search/components/RecommendNotice/index.tsx
+++ b/pages/search/components/RecommendNotice/index.tsx
@@ -3,19 +3,25 @@ import { NoticeList } from "@/lib/types/NoticeTypes";
 import styled from "@emotion/styled";
 import PostList from "../PostList";
 import { h2 } from "@/styles/fontsStyle";
+import useCookie from "@/hooks/useCookies";
+import { BASE_ADDRESS } from "./constants/constants";
 
 export default function RecommendNotice() {
-  // 추후에 로그인을 통해 가져올 데이터(쿠키나 다른 저장소나 상태관리 등)
-  const userId = "0dcb5feb-fe19-4b3d-b318-3a449b023461";
-  const { data: userData } = useUserData(userId);
-  const { data: noticesData } = useNoticesData(userData?.item?.address);
-  const notices = noticesData?.items ?? [];
+  const { id } = useCookie();
+  const { data: userData } = useUserData(id);
 
+  const address = userData?.item?.address
+    ? userData?.item?.address
+    : BASE_ADDRESS;
+
+  const { data: noticesData } = useNoticesData(address);
+
+  const notices = noticesData?.items ?? [];
   const noticeArray = notices.map((notice: NoticeList) => notice.item);
 
   return (
     <RecommendList>
-      <Header>맞춤 공고</Header>
+      <Header>추천 공고</Header>
       <CustomPostContent>
         <PostList isRecommend={true} noticeArray={noticeArray} />
       </CustomPostContent>


### PR DESCRIPTION
## 주요 변경 사항

- index 페이지의 추천 공고 뷰 수정했습니다.
- 이야기한거 민해보니 고객 정보에 address가 있을때만 해당 지역 공고를 보여주면 되는 것을 확인
- BASE_ADDRESS : 서울시 종로구로 해서 이외의 경우 다 서울시 종로구로 지정했습니다.


## 관련 스크린샷
알바님, 서울시 노원구로 세팅된 화면
![image](https://github.com/the-julge/the-julge/assets/151587265/c288ea49-b505-4b9a-92a4-5c6ef9f01a0b)


## 테스트 계획 또는 완료 사항

- 사장님 비로그인 상황에서 서울시 종로구값 가져 오는 것 확인했습니다.


## 리뷰어에게

-

