### PR TITLE
✨ TJ-56 공고 상세 사장님 지원목록 렌더링 및 승인/거절 요청

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -5,7 +5,7 @@ import { body2Regular } from "@/styles/fontsStyle";
 export interface ButtonProps {
   text: string;
   handleClick?: () => void;
-  color?: "colored" | "white" | "gray";
+  color?: "colored" | "white" | "gray" | "reject" | "accept";
   width?: number;
   type?: "button" | "submit" | "reset";
 }
@@ -28,6 +28,26 @@ export default function Button({
 
 const getColorStyles = (color: string) => {
   switch (color) {
+    case "reject":
+      return css`
+        background: var(--The-julge-gray-00);
+        color: var(--The-julge-red);
+        border: 1px solid var(--The-julge-red);
+
+        :active {
+          background: #fbb7af;
+        }
+      `;
+    case "accept":
+      return css`
+        background: var(--The-julge-gray-00);
+        color: var(--The-julge-blue-20);
+        border: 1px solid var(--The-julge-blue-20);
+
+        :active {
+          background: var(--The-julge-blue-10);
+        }
+      `;
     case "white":
       return css`
         background: var(--The-julge-gray-00);
@@ -63,7 +83,7 @@ const Wrapper = styled.div<{ $width?: number }>`
 `;
 
 const ButtonStyle = styled.button<{
-  $color?: "colored" | "white" | "gray";
+  $color?: "colored" | "white" | "gray" | "reject" | "accept";
 }>`
   display: inline-flex;
   padding: 12px 12px;

--- a/components/Table/components/TableBody/OwnerTableRow.tsx
+++ b/components/Table/components/TableBody/OwnerTableRow.tsx
@@ -1,15 +1,15 @@
+import Button from "@/components/Button/Button";
+import fetchData from "@/lib/apis/fetchData";
+import ModalContent from "@/pages/shops/[shopId]/notices/[noticeId]/components/ModalContent";
 import { body1Regular, body2Regular } from "@/styles/fontsStyle";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import Button from "@/components/Button/Button";
-import { useEffect, useState } from "react";
-import fetchData from "@/lib/apis/fetchData";
-import useCookie from "@/hooks/useCookies";
 import { useRouter } from "next/router";
-import ModalContent from "@/pages/shops/[shopId]/notices/[noticeId]/components/ModalContent";
+import { useState } from "react";
 
 type OwnerTableBodyProps = {
   key?: string;
+  token?: string;
   applicationId?: string;
   name?: string;
   bio?: string;
@@ -20,13 +20,13 @@ type OwnerTableBodyProps = {
 };
 
 export default function OwnerTableRow({
+  token,
   applicationId,
   name,
   bio,
   phone,
   status,
 }: OwnerTableBodyProps) {
-  const { jwt: token } = useCookie();
   const router = useRouter();
   const { shopId, noticeId } = router.query;
   const [isShowAcceptModal, setIsShowAcceptModal] = useState(false);
@@ -59,7 +59,7 @@ export default function OwnerTableRow({
       requestData: {
         status: "rejected",
       },
-      token: token,
+      token: token!,
     });
     setIsShowRejectModal(false);
     router.reload();

--- a/components/Table/components/TableBody/OwnerTableRow.tsx
+++ b/components/Table/components/TableBody/OwnerTableRow.tsx
@@ -6,8 +6,8 @@ import Button from "@/components/Button/Button";
 type OwnerTableBodyProps = {
   key?: string;
   name?: string;
-  description?: string;
-  phoneNumber?: string;
+  bio?: string;
+  phone?: string;
   status?: string;
   handlePermitClick?: () => void;
   handleDenyClick?: () => void;
@@ -15,8 +15,8 @@ type OwnerTableBodyProps = {
 
 export default function OwnerTableRow({
   name,
-  description,
-  phoneNumber,
+  bio,
+  phone,
   status,
   handlePermitClick,
   handleDenyClick,
@@ -25,24 +25,24 @@ export default function OwnerTableRow({
     <TableRow>
       <Cell>{name}</Cell>
       <Cell>
-        <Wrapper>{description}</Wrapper>
+        <Wrapper>{bio}</Wrapper>
       </Cell>
-      <Cell>{phoneNumber}</Cell>
+      <Cell>{phone?.replace(/(\d{3})(\d{4})(\d{4})/, "$1-$2-$3")}</Cell>
       <Cell>
-        {status === "대기중" ? (
+        {status === "pending" ? (
           <ButtonContainer>
             <ButtonWrapper>
               <Button
                 handleClick={handlePermitClick}
                 text="승인하기"
-                color="white"
+                color="accept"
               />
             </ButtonWrapper>
             <ButtonWrapper>
               <Button
                 handleClick={handleDenyClick}
                 text="거절하기"
-                color="white"
+                color="reject"
               />
             </ButtonWrapper>
           </ButtonContainer>
@@ -56,15 +56,15 @@ export default function OwnerTableRow({
 
 const getStatusStyle = (status: string) => {
   switch (status) {
-    case "승인 완료":
+    case "accepted":
       return css`
         background: var(--The-julge-blue-10);
         color: var(--The-julge-blue-20);
       `;
-    case "거절":
+    case "rejected":
       return css`
         background: var(--The-julge-red);
-        color: var(--The-julge-white, #fff);
+        color: var(--The-julge-gray-00);
       `;
   }
 };

--- a/components/Table/components/TableBody/OwnerTableRow.tsx
+++ b/components/Table/components/TableBody/OwnerTableRow.tsx
@@ -2,9 +2,15 @@ import { body1Regular, body2Regular } from "@/styles/fontsStyle";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import Button from "@/components/Button/Button";
+import { useEffect, useState } from "react";
+import fetchData from "@/lib/apis/fetchData";
+import useCookie from "@/hooks/useCookies";
+import { useRouter } from "next/router";
+import ModalContent from "@/pages/shops/[shopId]/notices/[noticeId]/components/ModalContent";
 
 type OwnerTableBodyProps = {
   key?: string;
+  applicationId?: string;
   name?: string;
   bio?: string;
   phone?: string;
@@ -14,43 +20,105 @@ type OwnerTableBodyProps = {
 };
 
 export default function OwnerTableRow({
+  applicationId,
   name,
   bio,
   phone,
   status,
-  handlePermitClick,
-  handleDenyClick,
 }: OwnerTableBodyProps) {
+  const { jwt: token } = useCookie();
+  const router = useRouter();
+  const { shopId, noticeId } = router.query;
+  const [isShowAcceptModal, setIsShowAcceptModal] = useState(false);
+  const [isShowRejectModal, setIsShowRejectModal] = useState(false);
+
+  const handleClickAccept = () => {
+    setIsShowAcceptModal(true);
+  };
+  const handleClickReject = () => {
+    setIsShowRejectModal(true);
+  };
+
+  const sendAcceptRequest = async () => {
+    console.log(applicationId);
+    const response = await fetchData({
+      param: `/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
+      method: "put",
+      requestData: {
+        status: "accepted",
+      },
+      token: token,
+    });
+    setIsShowAcceptModal(false);
+    router.reload();
+  };
+
+  const sendRejectRequest = async () => {
+    console.log(applicationId);
+    const response = await fetchData({
+      param: `/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
+      method: "put",
+      requestData: {
+        status: "rejected",
+      },
+      token: token,
+    });
+    setIsShowRejectModal(false);
+    router.reload();
+  };
+
   return (
-    <TableRow>
-      <Cell>{name}</Cell>
-      <Cell>
-        <Wrapper>{bio}</Wrapper>
-      </Cell>
-      <Cell>{phone?.replace(/(\d{3})(\d{4})(\d{4})/, "$1-$2-$3")}</Cell>
-      <Cell>
-        {status === "pending" ? (
-          <ButtonContainer>
-            <ButtonWrapper>
-              <Button
-                handleClick={handlePermitClick}
-                text="승인하기"
-                color="accept"
-              />
-            </ButtonWrapper>
-            <ButtonWrapper>
-              <Button
-                handleClick={handleDenyClick}
-                text="거절하기"
-                color="reject"
-              />
-            </ButtonWrapper>
-          </ButtonContainer>
-        ) : (
-          <Status status={status}>{status}</Status>
-        )}
-      </Cell>
-    </TableRow>
+    <>
+      <TableRow>
+        <Cell>{name}</Cell>
+        <Cell>
+          <Wrapper>{bio}</Wrapper>
+        </Cell>
+        <Cell>{phone?.replace(/(\d{3})(\d{4})(\d{4})/, "$1-$2-$3")}</Cell>
+        <Cell>
+          {status === "pending" ? (
+            <ButtonContainer>
+              <ButtonWrapper>
+                <Button
+                  handleClick={handleClickAccept}
+                  text="승인하기"
+                  color="accept"
+                />
+              </ButtonWrapper>
+              <ButtonWrapper>
+                <Button
+                  handleClick={handleClickReject}
+                  text="거절하기"
+                  color="reject"
+                />
+              </ButtonWrapper>
+            </ButtonContainer>
+          ) : (
+            <Status status={status}>
+              {status === "accepted" ? "승인 완료" : "거절"}
+            </Status>
+          )}
+        </Cell>
+      </TableRow>
+      {isShowAcceptModal && (
+        <ModalContent
+          modalIcon="check"
+          modalText="신청을 승인하시겠습니까?"
+          handleYesClick={sendAcceptRequest}
+          setModalState={setIsShowAcceptModal}
+          yesButtonText="승인하기"
+        />
+      )}
+      {isShowRejectModal && (
+        <ModalContent
+          modalIcon="check"
+          modalText="신청을 거절하시겠습니까?"
+          handleYesClick={sendRejectRequest}
+          setModalState={setIsShowRejectModal}
+          yesButtonText="거절하기"
+        />
+      )}
+    </>
   );
 }
 
@@ -64,6 +132,11 @@ const getStatusStyle = (status: string) => {
     case "rejected":
       return css`
         background: var(--The-julge-red);
+        color: var(--The-julge-gray-00);
+      `;
+    case "canceled":
+      return css`
+        background: var(--The-julge-gray-20);
         color: var(--The-julge-gray-00);
       `;
   }

--- a/components/Table/components/TableBody/OwnerTableRow.tsx
+++ b/components/Table/components/TableBody/OwnerTableRow.tsx
@@ -40,7 +40,6 @@ export default function OwnerTableRow({
   };
 
   const sendAcceptRequest = async () => {
-    console.log(applicationId);
     const response = await fetchData({
       param: `/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
       method: "put",
@@ -54,7 +53,6 @@ export default function OwnerTableRow({
   };
 
   const sendRejectRequest = async () => {
-    console.log(applicationId);
     const response = await fetchData({
       param: `/shops/${shopId}/notices/${noticeId}/applications/${applicationId}`,
       method: "put",

--- a/components/Table/components/TableBody/index.tsx
+++ b/components/Table/components/TableBody/index.tsx
@@ -18,10 +18,11 @@ export default function TableBody({
   return (
     <tbody>
       {dataList.map((data) => {
-        const { id, ...tableData } = data;
+        const { id, applicationId, ...tableData } = data;
         return type === "employer" ? (
           <OwnerTableRow
             key={id}
+            applicationId={applicationId}
             {...(tableData as Data)}
             handlePermitClick={handlePermitClick}
             handleDenyClick={handleDenyClick}

--- a/components/Table/components/TableBody/index.tsx
+++ b/components/Table/components/TableBody/index.tsx
@@ -4,6 +4,7 @@ import PartTimerTableRow from "./PartTimerTableRow";
 
 type TableBodyProps = {
   type: "employer" | "employee";
+  token?: string;
   dataList: Data[];
   handlePermitClick?: () => void;
   handleDenyClick?: () => void;
@@ -11,6 +12,7 @@ type TableBodyProps = {
 
 export default function TableBody({
   type,
+  token,
   dataList,
   handlePermitClick,
   handleDenyClick,
@@ -22,6 +24,7 @@ export default function TableBody({
         return type === "employer" ? (
           <OwnerTableRow
             key={id}
+            token={token}
             applicationId={applicationId}
             {...(tableData as Data)}
             handlePermitClick={handlePermitClick}

--- a/components/Table/index.tsx
+++ b/components/Table/index.tsx
@@ -8,6 +8,7 @@ export type Data = {
 };
 
 type TableProps = {
+  token?: string;
   type: "employer" | "employee";
   limit: number;
   count: number;
@@ -22,6 +23,7 @@ const Headers = {
 };
 
 export default function Table({
+  token,
   type,
   limit,
   count,
@@ -35,6 +37,7 @@ export default function Table({
         <TableHeader headers={Headers[type]} />
         <TableBody
           type={type}
+          token={token}
           dataList={dataList}
           handlePermitClick={handlePermitClick}
           handleDenyClick={handleDenyClick}

--- a/lib/apis/fetchData.tsx
+++ b/lib/apis/fetchData.tsx
@@ -1,5 +1,5 @@
-import { HttpMethod } from "@/lib/types/apiTypes";
-import axios, { AxiosResponse, AxiosError } from "axios";
+import axios, { AxiosResponse } from "axios";
+import handleAxiosError from "./handleAxiosError";
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
@@ -45,18 +45,5 @@ export default async function fetchData<T>({
     return response.data;
   } catch (error) {
     handleAxiosError(error);
-  }
-}
-
-function handleAxiosError(error: any): never {
-  const axiosError = error as AxiosError;
-  if (axiosError.response) {
-    throw new Error(
-      `Request failed with status code ${axiosError.response.status}`,
-    );
-  } else if (axiosError.request) {
-    throw new Error("No response received from server");
-  } else {
-    throw new Error(`Request failed with message: ${axiosError.message}`);
   }
 }

--- a/lib/apis/handleAxiosError.ts
+++ b/lib/apis/handleAxiosError.ts
@@ -1,0 +1,14 @@
+import { AxiosError } from "axios";
+
+export default function handleAxiosError(error: any): never {
+  const axiosError = error as AxiosError;
+  if (axiosError.response) {
+    throw new Error(
+      `Request failed with status code ${axiosError.response.status}`,
+    );
+  } else if (axiosError.request) {
+    throw new Error("No response received from server");
+  } else {
+    throw new Error(`Request failed with message: ${axiosError.message}`);
+  }
+}

--- a/lib/types/Application.ts
+++ b/lib/types/Application.ts
@@ -34,7 +34,7 @@ export interface ApplicationsResponse {
   items: ApplyResponse[];
   shop: Shop;
   status: string;
-  links: Link[];
+  links: ApplicantLink[];
 }
 
 export interface AppliedNotice {
@@ -55,7 +55,7 @@ interface Shop {
   item: ShopItem;
 }
 
-interface Link {
+export interface ApplicantLink {
   description: string;
   href: string;
   method: string;

--- a/lib/types/Application.ts
+++ b/lib/types/Application.ts
@@ -61,3 +61,28 @@ export interface ApplicantLink {
   method: string;
   rel: string;
 }
+
+export interface ApplicantItem {
+  item: {
+    user: {
+      href: string;
+      item: {
+        id: string;
+        name: string;
+        bio: string;
+        phone: string;
+      };
+    };
+    status: string;
+    id: string;
+  };
+}
+
+export interface ApplicantList {
+  count: number;
+  hasNext: boolean;
+  items: ApplicantItem[];
+  limit: number;
+  links: ApplicantLink[];
+  offset: number;
+}

--- a/pages/shops/[shopId]/index.page.tsx
+++ b/pages/shops/[shopId]/index.page.tsx
@@ -12,11 +12,13 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 import ModalContent from "./components/ModalContents";
 import validateFormData from "./utils/validateFormData";
+import useCookie from "@/hooks/useCookies";
 
 export default function NoticeRegistrationPage() {
   const router = useRouter();
   const { shopId } = router.query;
   const { showToast } = useToast();
+  const { jwt: token } = useCookie();
 
   const [modalState, setModalState] = useState({
     isOpen: false,
@@ -49,13 +51,14 @@ export default function NoticeRegistrationPage() {
         param: `/shops/${shopId}/notices`,
         method: "post",
         requestData: convertToISODate(modalState.formData),
+        token: token,
       });
 
       const { id: noticeId } = response.item;
       router.push(`/shops/${shopId}/notices/${noticeId}`);
       showToast(TOAST_MESSAGES.REGISTRATION_SUCCESSFUL);
     } catch (error) {
-      console.error("Error :", error);
+      console.error(error);
     } finally {
       setModalState((prevState) => ({ ...prevState, isOpen: false }));
     }

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employee/EmployeeButton.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employee/EmployeeButton.tsx
@@ -1,8 +1,7 @@
 import Button, { ButtonProps } from "@/components/Button/Button";
-import { useUser } from "@/contexts/UserContext";
-import useCookie from "@/hooks/useCookies";
 import fetchData from "@/lib/apis/fetchData";
 import { ApplicationsResponse, ApplyResponse } from "@/lib/types/Application";
+import { UserData } from "@/lib/types/userType";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import ModalContent from "../ModalContent";
@@ -10,14 +9,16 @@ import ModalContent from "../ModalContent";
 interface EmployeeButtonProps {
   applyHref: string;
   isClosed: boolean;
+  token: string;
+  userInfo: UserData | null;
 }
 
 export default function EmployeeButton({
   applyHref,
   isClosed,
+  token,
+  userInfo,
 }: EmployeeButtonProps) {
-  const { userInfo } = useUser();
-  const { jwt: token } = useCookie();
   const router = useRouter();
   const { shopId, noticeId } = router.query;
 

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employee/index.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employee/index.tsx
@@ -6,9 +6,10 @@ import updateRecentNotices from "../../utils/updateRecentNotices";
 
 interface EmployeeProps {
   noticeData: NoticeList;
+  token: string;
 }
 
-export default function Employee({ noticeData }: EmployeeProps) {
+export default function Employee({ noticeData, token }: EmployeeProps) {
   const noticeHref = noticeData.links[0].href.slice(18);
 
   useEffect(() => {
@@ -17,7 +18,7 @@ export default function Employee({ noticeData }: EmployeeProps) {
 
   return (
     <>
-      <PostDetail userType="employee" noticeData={noticeData} />
+      <PostDetail token={token} userType="employee" noticeData={noticeData} />
       <RecentNoticeContainer />
     </>
   );

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employee/index.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employee/index.tsx
@@ -1,8 +1,8 @@
 import { NoticeList } from "@/lib/types/NoticeTypes";
-import { useEffect } from "react";
-import updateRecentNotices from "../../utils/updateRecentNotices";
 import PostDetail from "../PostDetail";
 import RecentNoticeContainer from "./RecentNoticeContainer";
+import { useEffect } from "react";
+import updateRecentNotices from "../../utils/updateRecentNotices";
 
 interface EmployeeProps {
   noticeData: NoticeList;

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employer/ApplicantList.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employer/ApplicantList.tsx
@@ -5,10 +5,25 @@ import { h1Regular } from "@/styles/fontsStyle";
 import styled from "@emotion/styled";
 import { useRouter } from "next/router";
 
+interface ApplicantItem {
+  item: {
+    user: {
+      href: string;
+      item: {
+        id: string;
+        name: string;
+        bio: string;
+        phone: string;
+      };
+    };
+    status: string;
+  };
+}
+
 interface ApplicantList {
   count: number;
   hasNext: boolean;
-  items: Data[];
+  items: ApplicantItem[];
   limit: number;
   links: ApplicantLink[];
   offset: number;
@@ -21,7 +36,17 @@ export default function ApplicantList() {
     `/shops/${shopId}/notices/${noticeId}/applications`,
     "applicant",
   );
-  console.log(data);
+
+  const transformItems = (items: ApplicantItem[]): Data[] => {
+    const newItems = items.map((element) => ({
+      id: element.item.user.item.id,
+      name: element.item.user.item.name,
+      bio: element.item.user.item.bio,
+      phone: element.item.user.item.phone,
+      status: element.item.status,
+    }));
+    return newItems;
+  };
 
   return (
     data && (
@@ -31,7 +56,7 @@ export default function ApplicantList() {
           type="employer"
           limit={5}
           count={data.count}
-          dataList={data.items}
+          dataList={transformItems(data.items)}
         />
       </Wrapper>
     )

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employer/ApplicantList.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employer/ApplicantList.tsx
@@ -1,6 +1,6 @@
 import Table from "@/components/Table";
 import useFetchData from "@/hooks/useFetchData";
-import { ApplicantList } from "@/lib/types/Application";
+import type { ApplicantList } from "@/lib/types/Application";
 import { h1Regular } from "@/styles/fontsStyle";
 import styled from "@emotion/styled";
 import { useRouter } from "next/router";

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employer/ApplicantList.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employer/ApplicantList.tsx
@@ -1,13 +1,40 @@
-import Table from "@/components/Table";
+import Table, { Data } from "@/components/Table";
+import useFetchData from "@/hooks/useFetchData";
+import { ApplicantLink } from "@/lib/types/Application";
 import { h1Regular } from "@/styles/fontsStyle";
 import styled from "@emotion/styled";
+import { useRouter } from "next/router";
+
+interface ApplicantList {
+  count: number;
+  hasNext: boolean;
+  items: Data[];
+  limit: number;
+  links: ApplicantLink[];
+  offset: number;
+}
 
 export default function ApplicantList() {
+  const { query } = useRouter();
+  const { shopId, noticeId } = query;
+  const { data } = useFetchData<ApplicantList>(
+    `/shops/${shopId}/notices/${noticeId}/applications`,
+    "applicant",
+  );
+  console.log(data);
+
   return (
-    <Wrapper>
-      <Title>신청자 목록</Title>
-      {/* <Table type="employer" limit={5} count={4} dataList={} handlePermitClick={} handleDenyClick={}/> */}
-    </Wrapper>
+    data && (
+      <Wrapper>
+        <Title>신청자 목록</Title>
+        <Table
+          type="employer"
+          limit={5}
+          count={data.count}
+          dataList={data.items}
+        />
+      </Wrapper>
+    )
   );
 }
 

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employer/ApplicantList.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employer/ApplicantList.tsx
@@ -1,5 +1,5 @@
 import Table from "@/components/Table";
-import { ApplicantList } from "@/lib/types/Application";
+import type { ApplicantList } from "@/lib/types/Application";
 import { h1Regular } from "@/styles/fontsStyle";
 import styled from "@emotion/styled";
 import axios, { AxiosError } from "axios";

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employer/ApplicantList.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employer/ApplicantList.tsx
@@ -1,33 +1,10 @@
-import Table, { Data } from "@/components/Table";
+import Table from "@/components/Table";
 import useFetchData from "@/hooks/useFetchData";
-import { ApplicantLink } from "@/lib/types/Application";
+import { ApplicantList } from "@/lib/types/Application";
 import { h1Regular } from "@/styles/fontsStyle";
 import styled from "@emotion/styled";
 import { useRouter } from "next/router";
-
-interface ApplicantItem {
-  item: {
-    user: {
-      href: string;
-      item: {
-        id: string;
-        name: string;
-        bio: string;
-        phone: string;
-      };
-    };
-    status: string;
-  };
-}
-
-interface ApplicantList {
-  count: number;
-  hasNext: boolean;
-  items: ApplicantItem[];
-  limit: number;
-  links: ApplicantLink[];
-  offset: number;
-}
+import transformItems from "../../utils/transformItems";
 
 export default function ApplicantList() {
   const { query } = useRouter();
@@ -37,28 +14,19 @@ export default function ApplicantList() {
     "applicant",
   );
 
-  const transformItems = (items: ApplicantItem[]): Data[] => {
-    const newItems = items.map((element) => ({
-      id: element.item.user.item.id,
-      name: element.item.user.item.name,
-      bio: element.item.user.item.bio,
-      phone: element.item.user.item.phone,
-      status: element.item.status,
-    }));
-    return newItems;
-  };
-
   return (
     data && (
-      <Wrapper>
-        <Title>신청자 목록</Title>
-        <Table
-          type="employer"
-          limit={5}
-          count={data.count}
-          dataList={transformItems(data.items)}
-        />
-      </Wrapper>
+      <>
+        <Wrapper>
+          <Title>신청자 목록</Title>
+          <Table
+            type="employer"
+            limit={5}
+            count={data.count}
+            dataList={transformItems(data.items)}
+          />
+        </Wrapper>
+      </>
     )
   );
 }

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employer/ApplicantList.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employer/ApplicantList.tsx
@@ -1,3 +1,4 @@
+import Table from "@/components/Table";
 import { h1Regular } from "@/styles/fontsStyle";
 import styled from "@emotion/styled";
 
@@ -5,6 +6,7 @@ export default function ApplicantList() {
   return (
     <Wrapper>
       <Title>신청자 목록</Title>
+      {/* <Table type="employer" limit={5} count={4} dataList={} handlePermitClick={} handleDenyClick={}/> */}
     </Wrapper>
   );
 }

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employer/EmployerButton.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employer/EmployerButton.tsx
@@ -4,25 +4,17 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 interface EmployerButtonProps {
+  isMyNotice: boolean;
   token: string;
   userInfo: UserData | null;
 }
 
 export default function EmployerButton({
+  isMyNotice,
   token,
   userInfo,
 }: EmployerButtonProps) {
-  const [isMyNotice, setIsMyNotice] = useState(false);
   const router = useRouter();
-  const { shopId } = router.query;
-  console.log(userInfo);
-
-  useEffect(() => {
-    console.log(userInfo?.item.shop?.item.id === shopId);
-    if (userInfo?.item.shop?.item.id === shopId) {
-      setIsMyNotice(true);
-    }
-  }, []);
 
   const handleEditButtonClick = () => {
     // 공고 편집 버튼 클릭 시 실행되는 기능 구현

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employer/EmployerButton.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employer/EmployerButton.tsx
@@ -23,21 +23,14 @@ export default function EmployerButton({
 
   return (
     <>
-      {/** 내 공고인 경우 */}
-      {isMyNotice && (
+      {isMyNotice ? (
         <Button
           text="공고 편집하기"
           color="white"
           handleClick={handleEditButtonClick}
         />
-      )}
-      {/** 내 공고가 아닌 경우 */}
-      {!isMyNotice && (
-        <Button
-          text="공고 편집하기"
-          color="gray"
-          handleClick={handleEditButtonClick}
-        />
+      ) : (
+        <Button text="공고 편집하기" color="gray" />
       )}
     </>
   );

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employer/EmployerButton.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employer/EmployerButton.tsx
@@ -1,8 +1,28 @@
 import Button from "@/components/Button/Button";
-import { useState } from "react";
+import { UserData } from "@/lib/types/userType";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 
-export default function EmployerButton() {
+interface EmployerButtonProps {
+  token: string;
+  userInfo: UserData | null;
+}
+
+export default function EmployerButton({
+  token,
+  userInfo,
+}: EmployerButtonProps) {
   const [isMyNotice, setIsMyNotice] = useState(false);
+  const router = useRouter();
+  const { shopId } = router.query;
+  console.log(userInfo);
+
+  useEffect(() => {
+    console.log(userInfo?.item.shop?.item.id === shopId);
+    if (userInfo?.item.shop?.item.id === shopId) {
+      setIsMyNotice(true);
+    }
+  }, []);
 
   const handleEditButtonClick = () => {
     // 공고 편집 버튼 클릭 시 실행되는 기능 구현

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employer/index.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employer/index.tsx
@@ -14,11 +14,7 @@ export default function Employer({ noticeData }: { noticeData: NoticeList }) {
   const [isMyNotice, setIsMyNotice] = useState(false);
   const noticeHref = noticeData.links[0].href.slice(18);
 
-  console.log(userInfo);
-  console.log(isMyNotice);
-
   useEffect(() => {
-    console.log(userInfo?.item.shop?.item.id === shopId);
     if (userInfo?.item.shop?.item.id === shopId) {
       setIsMyNotice(true);
     } else {

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employer/index.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employer/index.tsx
@@ -7,7 +7,13 @@ import { useRouter } from "next/router";
 import RecentNoticeContainer from "../Employee/RecentNoticeContainer";
 import updateRecentNotices from "../../utils/updateRecentNotices";
 
-export default function Employer({ noticeData }: { noticeData: NoticeList }) {
+export default function Employer({
+  noticeData,
+  token,
+}: {
+  noticeData: NoticeList;
+  token: string;
+}) {
   const { userInfo } = useUser();
   const { query } = useRouter();
   const { shopId } = query;
@@ -25,11 +31,12 @@ export default function Employer({ noticeData }: { noticeData: NoticeList }) {
   return (
     <>
       <PostDetail
+        token={token}
         isMyNotice={isMyNotice}
         userType="employer"
         noticeData={noticeData}
       />
-      {isMyNotice ? <ApplicantList /> : <RecentNoticeContainer />}
+      {isMyNotice ? <ApplicantList token={token} /> : <RecentNoticeContainer />}
     </>
   );
 }

--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employer/index.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employer/index.tsx
@@ -1,12 +1,39 @@
 import { NoticeList } from "@/lib/types/NoticeTypes";
 import PostDetail from "../PostDetail";
 import ApplicantList from "./ApplicantList";
+import { useUser } from "@/contexts/UserContext";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import RecentNoticeContainer from "../Employee/RecentNoticeContainer";
+import updateRecentNotices from "../../utils/updateRecentNotices";
 
 export default function Employer({ noticeData }: { noticeData: NoticeList }) {
+  const { userInfo } = useUser();
+  const { query } = useRouter();
+  const { shopId } = query;
+  const [isMyNotice, setIsMyNotice] = useState(false);
+  const noticeHref = noticeData.links[0].href.slice(18);
+
+  console.log(userInfo);
+  console.log(isMyNotice);
+
+  useEffect(() => {
+    console.log(userInfo?.item.shop?.item.id === shopId);
+    if (userInfo?.item.shop?.item.id === shopId) {
+      setIsMyNotice(true);
+    } else {
+      updateRecentNotices(noticeHref);
+    }
+  }, []);
+
   return (
     <>
-      <PostDetail userType="employer" noticeData={noticeData} />
-      <ApplicantList />
+      <PostDetail
+        isMyNotice={isMyNotice}
+        userType="employer"
+        noticeData={noticeData}
+      />
+      {isMyNotice ? <ApplicantList /> : <RecentNoticeContainer />}
     </>
   );
 }

--- a/pages/shops/[shopId]/notices/[noticeId]/components/ModalContent.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/ModalContent.tsx
@@ -53,5 +53,5 @@ const Dimmed = styled.div`
   width: 100vw;
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.2);
-  z-index: 1;
+  z-index: 2;
 `;

--- a/pages/shops/[shopId]/notices/[noticeId]/components/PostCard.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/PostCard.tsx
@@ -1,8 +1,10 @@
+import useCookie from "@/hooks/useCookies";
 import { NoticeList } from "@/lib/types/NoticeTypes";
 import styled from "@emotion/styled";
 import EmployeeButton from "./Employee/EmployeeButton";
 import EmployerButton from "./Employer/EmployerButton";
 import PostInformation from "./PostInformation";
+import { useUser } from "@/contexts/UserContext";
 
 interface PostCardType {
   userType: string;
@@ -11,6 +13,8 @@ interface PostCardType {
 
 export default function PostCard({ userType, noticeData }: PostCardType) {
   const applyHref = noticeData.links[3].href.slice(18);
+  const { jwt: token } = useCookie();
+  const { userInfo } = useUser();
 
   return (
     <Wrapper>
@@ -19,13 +23,15 @@ export default function PostCard({ userType, noticeData }: PostCardType) {
       </ImageContainer>
       <Container>
         <PostInformation noticeData={noticeData} />
-        {userType !== "employee" ? (
+        {userType === "employee" ? (
           <EmployeeButton
             applyHref={applyHref}
             isClosed={noticeData.item.closed}
+            token={token}
+            userInfo={userInfo}
           />
         ) : (
-          <EmployerButton />
+          <EmployerButton token={token} userInfo={userInfo} />
         )}
       </Container>
     </Wrapper>

--- a/pages/shops/[shopId]/notices/[noticeId]/components/PostCard.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/PostCard.tsx
@@ -7,18 +7,19 @@ import PostInformation from "./PostInformation";
 import { useUser } from "@/contexts/UserContext";
 
 interface PostCardType {
+  token: string;
   userType: string;
   noticeData: NoticeList;
   isMyNotice?: boolean;
 }
 
 export default function PostCard({
+  token,
   userType,
   noticeData,
   isMyNotice,
 }: PostCardType) {
   const applyHref = noticeData.links[3].href.slice(18);
-  const { jwt: token } = useCookie();
   const { userInfo } = useUser();
 
   return (

--- a/pages/shops/[shopId]/notices/[noticeId]/components/PostCard.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/PostCard.tsx
@@ -9,9 +9,14 @@ import { useUser } from "@/contexts/UserContext";
 interface PostCardType {
   userType: string;
   noticeData: NoticeList;
+  isMyNotice?: boolean;
 }
 
-export default function PostCard({ userType, noticeData }: PostCardType) {
+export default function PostCard({
+  userType,
+  noticeData,
+  isMyNotice,
+}: PostCardType) {
   const applyHref = noticeData.links[3].href.slice(18);
   const { jwt: token } = useCookie();
   const { userInfo } = useUser();
@@ -31,7 +36,11 @@ export default function PostCard({ userType, noticeData }: PostCardType) {
             userInfo={userInfo}
           />
         ) : (
-          <EmployerButton token={token} userInfo={userInfo} />
+          <EmployerButton
+            isMyNotice={isMyNotice!}
+            token={token}
+            userInfo={userInfo}
+          />
         )}
       </Container>
     </Wrapper>

--- a/pages/shops/[shopId]/notices/[noticeId]/components/PostDetail.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/PostDetail.tsx
@@ -4,12 +4,14 @@ import styled from "@emotion/styled";
 import PostCard from "./PostCard";
 
 interface PostDetailProps {
+  token: string;
   userType: string;
   noticeData: NoticeList;
   isMyNotice?: boolean;
 }
 
 export default function PostDetail({
+  token,
   userType,
   noticeData,
   isMyNotice,
@@ -23,6 +25,7 @@ export default function PostDetail({
         <Title>{noticeData.item.shop.item.name}</Title>
       </ShopDetails>
       <PostCard
+        token={token}
         isMyNotice={isMyNotice}
         userType={userType}
         noticeData={noticeData}

--- a/pages/shops/[shopId]/notices/[noticeId]/components/PostDetail.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/PostDetail.tsx
@@ -6,9 +6,14 @@ import PostCard from "./PostCard";
 interface PostDetailProps {
   userType: string;
   noticeData: NoticeList;
+  isMyNotice?: boolean;
 }
 
-export default function PostDetail({ userType, noticeData }: PostDetailProps) {
+export default function PostDetail({
+  userType,
+  noticeData,
+  isMyNotice,
+}: PostDetailProps) {
   if (!noticeData) return <div>loading...</div>;
 
   return (
@@ -17,7 +22,11 @@ export default function PostDetail({ userType, noticeData }: PostDetailProps) {
         <Category>{noticeData.item.shop.item.category}</Category>
         <Title>{noticeData.item.shop.item.name}</Title>
       </ShopDetails>
-      <PostCard userType={userType} noticeData={noticeData} />
+      <PostCard
+        isMyNotice={isMyNotice}
+        userType={userType}
+        noticeData={noticeData}
+      />
       <PostDescription>
         <DescriptionHeading>공고 설명</DescriptionHeading>
         <DescriptionText>{noticeData.item.description}</DescriptionText>

--- a/pages/shops/[shopId]/notices/[noticeId]/components/PostInformation.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/PostInformation.tsx
@@ -49,12 +49,12 @@ export default function PostInformation({
 }
 
 const Wrapper = styled.div`
-  margin-top: 16px;
   position: relative;
   display: flex;
   flex-direction: column;
   gap: 12px;
   width: 100%;
+  margin-bottom: 12px;
 `;
 
 const Wage = styled.span`

--- a/pages/shops/[shopId]/notices/[noticeId]/index.page.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/index.page.tsx
@@ -9,11 +9,8 @@ import { useUser } from "@/contexts/UserContext";
 
 export default function NoticeDetailPage() {
   const { userInfo } = useUser();
-
-  const {
-    query: { shopId, noticeId },
-  } = useRouter();
-
+  const { query } = useRouter();
+  const { shopId, noticeId } = query;
   const {
     isLoading,
     error,

--- a/pages/shops/[shopId]/notices/[noticeId]/index.page.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/index.page.tsx
@@ -6,11 +6,14 @@ import { useRouter } from "next/router";
 import Employee from "./components/Employee";
 import Employer from "./components/Employer";
 import { useUser } from "@/contexts/UserContext";
+import useCookie from "@/hooks/useCookies";
 
 export default function NoticeDetailPage() {
   const { userInfo } = useUser();
   const { query } = useRouter();
   const { shopId, noticeId } = query;
+  const { jwt: token } = useCookie();
+
   const {
     isLoading,
     error,
@@ -28,9 +31,9 @@ export default function NoticeDetailPage() {
     <Layout>
       <Wrapper>
         {userInfo.item.type === "employee" ? (
-          <Employee noticeData={noticeData} />
+          <Employee noticeData={noticeData} token={token} />
         ) : (
-          <Employer noticeData={noticeData} />
+          <Employer noticeData={noticeData} token={token} />
         )}
       </Wrapper>
     </Layout>

--- a/pages/shops/[shopId]/notices/[noticeId]/utils/transformItems.ts
+++ b/pages/shops/[shopId]/notices/[noticeId]/utils/transformItems.ts
@@ -1,0 +1,14 @@
+import { Data } from "@/components/Table";
+import { ApplicantItem } from "@/lib/types/Application";
+
+export default function transformItems(items: ApplicantItem[]): Data[] {
+  const newItems = items.map((element) => ({
+    id: element.item.user.item.id,
+    name: element.item.user.item.name,
+    bio: element.item.user.item.bio,
+    phone: element.item.user.item.phone,
+    status: element.item.status,
+    applicationId: element.item.id,
+  }));
+  return newItems;
+}


### PR DESCRIPTION
## 주요 변경 사항

- 사장님 공고 상세 접속 시 내 가게의 공고면 편집버튼 활성화
- 내 공고가 아니면 사장님 회원의 경우에도 최근에 본 공고 뜨도록 수정
- 지원자 목록 띄우고 공고 승인/거절 요청 기능

## 관련 이슈

- 한명 승인하면 공고 자체가 마감되어버려서 거절 버튼 누르면 이미 마감된 오류라는 403오류가 떠서 그 부분 수정할 예정입니다. ( isClosed옵션을 어떻게 할 수 있는 방법이 없어는 것 같아요 .. )
- 테이블 tbody안에서 div태그를 쓸 수 없다는 경고가 콘솔에 발생하긴 하는데 modal에서 버튼을 누르면 승인요청이 날아가게 해야하는데 요청 시 필요한 applicaitonId값이 table안에서 특정할 수 있는 것 같아서 일단 넣어서 했습니다.. 부모컴포넌트에서 applicaitonId값 쓸 수 있는 방법 찾아보고 찾으면 수정할 예정입니다

## 관련 스크린샷

- ~~일단 limit을 5로주고 count는 보이다시피 6인데 왜 한번에 6개가 다뜨고 2페이지도 똑같은 내용인지 모르겠어요 ㅋㅋ ㅠㅠ 일단 낼 미팅때 테이블 컴포넌트 어떻게 사용한건지 얘기해야할 것 같습니다..!~~
해결완료

<img width="600" alt="image" src="https://github.com/the-julge/the-julge/assets/127701092/e716cef3-9204-4fde-b3b1-14056af95063">
<img width="600" alt="image" src="https://github.com/the-julge/the-julge/assets/127701092/7b8e890c-aad1-4bd3-98af-38bd89b09f9b">


## 리뷰어에게

- 매번 필요한 곳에서 useCookie를 쓰는게 맞나요..? 일단 제가 넘 auth요청 많이 보내서 상단에섭 불러와서 prop으로 내려주긴했는데 드릴링 장난아니라서 여쭤봅니다 ..ㅋㅋㅋㅋㅋㅋㅋ
<img width="445" alt="image" src="https://github.com/the-julge/the-julge/assets/127701092/4ccbc99d-e0a5-45e2-82e9-42789ff40d74">
이렇게 가서 그냥 한번 불러와서 계속 내려줬습니다

- 이렇게 공고가 마감된 상태에서 요청을 보내면 죄다 403오류가 나기때문에, 지원요청 승인하기전에 그 요청빼고 다 거절해버려야하는건지 그냥 에러 처리만 해주면되는건지 뭔지... 낼 주강사님 호출하겠습니다

https://github.com/the-julge/the-julge/assets/127701092/ca2e1111-0490-44cb-8018-c3723e25baba

- 점점 리팩토링과 클린코드를 포기하고 있는 상황입니다 ㅎ.. 공고상세 페이지 왜이렇게 요청보내는게 많죠..?ㅋㅋㅋㅋㅋㅋㅋ
