### PR TITLE
✨ TJ-66 내 프로필 레이아웃 및 연동

### DIFF
--- a/pages/my-profile/components/ProfileCard.tsx/ProfileContent.tsx
+++ b/pages/my-profile/components/ProfileCard.tsx/ProfileContent.tsx
@@ -1,0 +1,91 @@
+import { body1Regular, body2Regular, h1Regular } from "@/styles/fontsStyle";
+import styled from "@emotion/styled";
+import Image from "next/image";
+
+type ProfileContentProps = {
+  name: string;
+  phone: string;
+  address: string;
+};
+
+export default function ProfileContent({
+  name,
+  phone,
+  address,
+}: ProfileContentProps) {
+  return (
+    <Wrapper>
+      <NameContainer>
+        이름
+        <Name>{name ?? "나는짱"}</Name>
+      </NameContainer>
+      <PhoneContainer>
+        <Image src="/images/phone.svg" alt="전화번호" width={20} height={20} />
+
+        {phone ?? "010-1234-5678"}
+      </PhoneContainer>
+      <AddressContainer>
+        <Image
+          src="/images/location.svg"
+          alt="선호지역"
+          width={20}
+          height={20}
+        />
+        <div>선호지역:</div>
+        {address ?? "서울시 도봉구"}
+      </AddressContainer>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  @media (max-width: 767px) {
+    gap: 8px;
+  }
+`;
+
+const NameContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--The-julge-purple-40);
+  ${body1Regular}
+  line-height: 20px;
+
+  @media (max-width: 767px) {
+    ${body2Regular}
+  }
+`;
+
+const Name = styled.div`
+  color: var(--The-julge-black);
+  ${h1Regular}
+`;
+
+const PhoneContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--The-julge-gray-50);
+  ${body1Regular}
+
+  @media (max-width: 767px) {
+    ${body2Regular}
+  }
+`;
+
+const AddressContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--The-julge-gray-50);
+  ${body1Regular}
+
+  @media (max-width: 767px) {
+    ${body2Regular}
+  }
+`;

--- a/pages/my-profile/components/ProfileCard.tsx/ProfileContent.tsx
+++ b/pages/my-profile/components/ProfileCard.tsx/ProfileContent.tsx
@@ -17,12 +17,12 @@ export default function ProfileContent({
     <Wrapper>
       <NameContainer>
         이름
-        <Name>{name ?? "나는짱"}</Name>
+        <Name>{name}</Name>
       </NameContainer>
       <PhoneContainer>
         <Image src="/images/phone.svg" alt="전화번호" width={20} height={20} />
 
-        {phone ?? "010-1234-5678"}
+        {phone}
       </PhoneContainer>
       <AddressContainer>
         <Image
@@ -32,7 +32,7 @@ export default function ProfileContent({
           height={20}
         />
         <div>선호지역:</div>
-        {address ?? "서울시 도봉구"}
+        {address}
       </AddressContainer>
     </Wrapper>
   );

--- a/pages/my-profile/components/ProfileCard.tsx/index.tsx
+++ b/pages/my-profile/components/ProfileCard.tsx/index.tsx
@@ -16,7 +16,7 @@ export default function ProfileCard(props: ProfileCardProps) {
     <Wrapper>
       <ContentContainer>
         <ProfileContent {...rest} />
-        <Biograph>{bio ?? "열심히 일하겠습니다."}</Biograph>
+        <Biograph>{bio}</Biograph>
       </ContentContainer>
       <ButtonContainer>
         <Button text="편집하기" color="white" />

--- a/pages/my-profile/components/ProfileCard.tsx/index.tsx
+++ b/pages/my-profile/components/ProfileCard.tsx/index.tsx
@@ -1,0 +1,59 @@
+import { body1Regular } from "@/styles/fontsStyle";
+import styled from "@emotion/styled";
+import ProfileContent from "./ProfileContent";
+import Button from "@/components/Button/Button";
+
+type ProfileCardProps = {
+  bio: string;
+  name: string;
+  phone: string;
+  address: string;
+};
+
+export default function ProfileCard(props: ProfileCardProps) {
+  const { bio, ...rest } = props;
+  return (
+    <Wrapper>
+      <ContentContainer>
+        <ProfileContent {...rest} />
+        <Biograph>{bio ?? "열심히 일하겠습니다."}</Biograph>
+      </ContentContainer>
+      <ButtonContainer>
+        <Button text="편집하기" color="white" />
+      </ButtonContainer>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 32px;
+  border-radius: 12px;
+  background: var(--The-julge-purple-10, #e9dcf4);
+
+  @media (max-width: 767px) {
+    padding: 20px;
+  }
+`;
+
+const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+
+  @media (max-width: 767px) {
+    gap: 20px;
+  }
+`;
+const ButtonContainer = styled.div`
+  width: 169px;
+
+  @media (max-width: 767px) {
+    width: 108px;
+  }
+`;
+
+const Biograph = styled.div`
+  ${body1Regular}
+`;

--- a/pages/my-profile/components/UserProfile/index.tsx
+++ b/pages/my-profile/components/UserProfile/index.tsx
@@ -2,6 +2,7 @@ import { body1Regular, body2Regular, h1Regular, h3 } from "@/styles/fontsStyle";
 import Button from "@/components/Button/Button";
 import styled from "@emotion/styled";
 import Link from "next/link";
+import ProfileCard from "../ProfileCard.tsx";
 
 type UserProfileProps = {
   name: string;
@@ -10,30 +11,32 @@ type UserProfileProps = {
   bio: string;
 };
 
-export default function UserProfile({
-  name,
-  phone,
-  address,
-  bio,
-}: UserProfileProps) {
+export default function UserProfile(props: UserProfileProps) {
+  const { name, phone, address, bio } = props;
+  const hasProfile = !!(name || phone || address || bio);
   return (
-    <Wrapper>
+    <Wrapper hasProfile={hasProfile}>
       <Title>내 프로필</Title>
-      <NoApplication>
-        <Description>
-          내 프로필을 등록하고 원하는 가게에 지원해 보세요.
-        </Description>
-        <ButtonContainer>
-          <Link href="/">
-            <Button text="내 프로필 등록하기" />
-          </Link>
-        </ButtonContainer>
-      </NoApplication>
+
+      {hasProfile ? (
+        <ProfileCard {...props} />
+      ) : (
+        <NoApplication>
+          <Description>
+            내 프로필을 등록하고 원하는 가게에 지원해 보세요.
+          </Description>
+          <ButtonContainer>
+            <Link href="/">
+              <Button text="내 프로필 등록하기" />
+            </Link>
+          </ButtonContainer>
+        </NoApplication>
+      )}
     </Wrapper>
   );
 }
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ hasProfile: boolean }>`
   max-width: 964px;
   margin: 0 auto;
   display: flex;

--- a/public/images/phone.svg
+++ b/public/images/phone.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3" width="14" height="20" rx="2" fill="#B182D5"/>
+<rect width="10" height="14" transform="translate(5 3)" fill="white"/>
+</svg>


### PR DESCRIPTION
## 주요 변경 사항
- 내 프로필 레이아웃 추가
- API와 연동해서 등록한 프로필이 없으면 프로필 페이지로 가는 버튼 출력

## 관련 스크린샷
### 프로필 정보가 없을 때
![image](https://github.com/the-julge/the-julge/assets/119824778/219dc46d-507b-4247-8c4d-7db6ff1b0666)
### 프로필 정보가 있을 때
![image](https://github.com/the-julge/the-julge/assets/119824778/c67ba0e4-98f0-4729-b052-0c5152bae3cd)

## 테스트 계획 또는 완료 사항
- 프로필 등록 시 전화번호에 하이픈('-')을 안붙였을 때도 붙여서 나오도록 처리할것 같습니다.
- 반응형 디자인은 추후 추가 예정입니다.

## 리뷰어에게
- 변경해야할 부분이 있으면 말씀해주시면 반영하겠습니다.