### PR TITLE
🐛 bugfix: 프로필 임시로 true로 고정해둔 부분 수정

### DIFF
--- a/pages/shops/[shopId]/notices/[noticeId]/components/Employee/EmployeeButton.tsx
+++ b/pages/shops/[shopId]/notices/[noticeId]/components/Employee/EmployeeButton.tsx
@@ -26,8 +26,7 @@ export default function EmployeeButton({
   const router = useRouter();
   const { shopId, noticeId } = router.query;
 
-  // const isProfileExist = userInfo?.item.name;
-  const isProfileExist = true; // 임시로 true로 고정
+  const isProfileExist = userInfo?.item.name;
 
   const [applicationId, setApplicationId] = useState<string>("");
   const [isApplied, setIsApplied] = useState(false);
@@ -67,7 +66,6 @@ export default function EmployeeButton({
   const handleApplyButtonClick = () => {
     if (isProfileExist) {
       setShowApplyModal(true);
-      // 마운트될 때와 버튼 클릭시에 applicationId 갱신
       getUserApplications();
     } else {
       setShowProfileCheckModal(true);
@@ -176,7 +174,7 @@ export default function EmployeeButton({
           modalText="내 프로필을 먼저 등록해주세요"
           handleYesClick={() => {
             setShowProfileCheckModal(false);
-            router.push("/myprofile");
+            router.push("/my-profile");
           }}
         />
       )}


### PR DESCRIPTION
## 주요 변경 사항

- 테스트한다고 유저 프로필 검사하는부분 true로 해놨다가 수정안해서 급하게 수정합니다..! 어쩐지 아무 프로필도 없는 사람이 공고 신청이 되더라구요.

## 관련 스크린샷

그래서 이렇게 아무것도 없는 유저가 떠버림.. ㅎㅎ..
<img width="1029" alt="image" src="https://github.com/the-julge/the-julge/assets/127701092/76adc0eb-f28e-4727-a09c-c9952072748c">
<img width="1103" alt="image" src="https://github.com/the-julge/the-julge/assets/127701092/3cc5af01-bddd-4e61-99a4-555db3b58dfb">


## 리뷰어에게

: 내일 코어타임전까지..? 
- guest일 경우 로딩화면만 뜨게 해놔서 그 부분 수정하고 
- 테이블 태그에 div 집어넣지말라는 경고뜨는거 해결하고
- noticeId가져오기전에는 요청보내지말라고하는거 수정하고
- filter컴포넌트에 input type datetime-local인 부분 적용할 예정입니다! 

( 이거 빨리하면 다른것들,  404페이지나 로딩 스켈레톤, datetime-local타입으로 했던 부분도 좀 불편한것 같아서 datetime-picker라이브러리 쓸 수 있나 찾아보고 ,페이지 타이틀 바꾸는거랑 그런 잡다한거 해보려구요..!? (빨리못하면 안할예정))
