### PR TITLE
✨ TJ-68 필터링 시 과거 날짜 선택 막기

### DIFF
--- a/components/Filter/Filter.tsx
+++ b/components/Filter/Filter.tsx
@@ -9,6 +9,7 @@ import {
   LocationString,
   SelectedLocationList,
 } from "./types/types";
+import { useToast } from "@/contexts/ToastContext";
 
 export default function Filter({
   isModalVisible,
@@ -19,6 +20,7 @@ export default function Filter({
     useState<SelectedLocationList>([]);
   const [startsAtValue, setStartsAtValue] = useState<string>("");
   const [hourlyPayValue, setHourlyPayValue] = useState<string>("");
+  const { showToast } = useToast();
 
   const toggleLocation = (location: LocationString) => {
     if (selectedLocations.includes(location)) {
@@ -28,6 +30,18 @@ export default function Filter({
     } else {
       setSelectedLocations([...selectedLocations, location]);
     }
+  };
+
+  const handleChangeStartsAt = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newDate = e.target.value;
+    const currentDate = new Date();
+
+    console.log(newDate);
+    console.log(currentDate);
+
+    if (new Date(newDate).getTime() <= currentDate.getTime())
+      showToast("과거 날짜는 선택할 수 없습니다.");
+    else setStartsAtValue(newDate);
   };
 
   const clearFilters = () => {
@@ -60,7 +74,7 @@ export default function Filter({
           type="datetime-local"
           max="9999-12-31T23:59"
           value={startsAtValue}
-          onChange={(e) => setStartsAtValue(e.target.value)}
+          onChange={handleChangeStartsAt}
         />
         <BorderLine />
         <Subtitle>금액</Subtitle>


### PR DESCRIPTION
## 주요 변경 사항

- 필터 모달에서 과거 날짜 + 현재 날짜 선택 시 반영되지 않도록 반영


## 관련 이슈

- 사실 왜 과거 공고는 필터링 못하게 해놨는지 이해할 수 없어요...

## 관련 스크린샷

![image](https://github.com/the-julge/the-julge/assets/127701092/372b7492-1786-4f8d-98e1-c869386043b9)


## 리뷰어에게

- 오늘날짜도 과거로 생각하는 걸 간과해서 현우님을 당황시킨점 죄송합니다.. 
